### PR TITLE
Adapting OpenMC read procedure able to read electron data

### DIFF
--- a/framework/materials/multi_group_xs/multi_group_xs.cc
+++ b/framework/materials/multi_group_xs/multi_group_xs.cc
@@ -110,6 +110,16 @@ MultiGroupXS::Initialize(std::vector<std::pair<int, double>>& combinations)
       precursors_.resize(n_precs);
     }
   }
+  
+  // Init electron data
+  if (is_bxslib_)
+  {
+    sigma_e_.assign(n_grps, 0.0);
+    sigma_c_.assign(n_grps, 0.0);
+    stopping_power_.assign(n_grps, 0.0);
+    momentum_transfer_.assign(n_grps, 0.0);
+    density_.assign(n_grps, 0.0);
+  } 
 
   // Combine the data
   size_t precursor_count = 0;
@@ -215,11 +225,17 @@ MultiGroupXS::Reset()
   scattering_order_ = 0;
   num_precursors_ = 0;
   is_fissionable_ = false;
-
+  is_bxslib_ = false;
   sigma_t_.clear();
   sigma_a_.clear();
   transfer_matrices_.clear();
 
+  sigma_e_.clear();
+  sigma_c_.clear();
+  stopping_power_.clear();
+  momentum_transfer_.clear();
+  density_.clear();
+  
   sigma_f_.clear();
   chi_.clear();
   nu_sigma_f_.clear();

--- a/framework/materials/multi_group_xs/multi_group_xs.h
+++ b/framework/materials/multi_group_xs/multi_group_xs.h
@@ -16,6 +16,7 @@ public:
       scattering_order_(0),
       num_precursors_(0),
       is_fissionable_(false),
+      is_bxslib_(false),
       adjoint_(false),
       scaling_factor_(1.0),
       diffusion_initialized_(false)
@@ -68,6 +69,8 @@ public:
   size_t GetNumPrecursors() const { return num_precursors_; }
 
   bool IsFissionable() const { return is_fissionable_; }
+  
+  bool IsBxslib() const { return is_bxslib_; }
 
   void SetAdjointMode(bool val)
   {
@@ -83,6 +86,16 @@ public:
   const std::vector<double>& GetSigmaTotal() const { return sigma_t_; }
 
   const std::vector<double>& GetSigmaAbsorption() const { return sigma_a_; }
+  
+  const std::vector<double>& GetSigmaEdep() const { return sigma_e_; }
+
+  const std::vector<double>& GetSigmaCdep() const { return sigma_c_; }
+  
+  const std::vector<double>& GetStoppingPower() const { return stopping_power_; }
+
+  const std::vector<double>& GetMomentumTransfer() const { return momentum_transfer_; }
+
+  const std::vector<double>& GetDensity() const { return density_; }
 
   const std::vector<SparseMatrix>& GetTransferMatrices() const
   {
@@ -132,6 +145,8 @@ private:
   size_t num_precursors_;
   /// Is fissionable?
   bool is_fissionable_;
+  /// Is charged particle?
+  bool is_bxslib_;
   /// Can be used for adjoint calculations
   bool adjoint_;
   /// An arbitrary scaling factor
@@ -146,6 +161,16 @@ private:
   std::vector<double> sigma_a_;
   /// Fission cross section
   std::vector<double> sigma_f_;
+  /// Energy deposition cross section
+  std::vector<double> sigma_e_;
+  /// Charge deposition cross section
+  std::vector<double> sigma_c_;
+  /// Stopping power data
+  std::vector<double> stopping_power_;
+  /// Momentum transfer data
+  std::vector<double> momentum_transfer_;
+  /// Material density data
+  std::vector<double> density_;
   /// Neutron production due to fission
   std::vector<double> nu_sigma_f_;
   /// Neutron fission spectrum

--- a/framework/materials/multi_group_xs/openmc_import.cc
+++ b/framework/materials/multi_group_xs/openmc_import.cc
@@ -29,9 +29,9 @@ MultiGroupXS::Initialize(const std::string& file_name,
   std::string filetype;
   H5ReadAttribute<std::string>(file, "filetype", filetype);
   if (filetype != "mgxs")
-    throw std::runtime_error(file_name + " is not a valid OpenMC library file");
+    throw std::runtime_error(file_name + " is not a valid HDF5 library file");
 
-  log.Log() << "Reading OpenMC cross-section file \"" << file_name << "\"\n";
+  log.Log() << "Reading HDF5 cross-section file \"" << file_name << "\"\n";
 
   // Number of groups
   if (not H5ReadAttribute<size_t>(file, "energy_groups", num_groups_))
@@ -106,7 +106,42 @@ MultiGroupXS::Initialize(const std::string& file_name,
   if (sigma_a_.empty())
     ComputeAbsorption();
   ComputeDiffusionParameters();
-
+  
+  // Is charged particle?
+  H5ReadGroupAttribute<bool>(file, dataset_name, "bxslib", is_bxslib_);
+  if (is_bxslib_)
+  {
+    // Energy deposition
+    H5ReadDataset1D<double>(file, path + "edep", sigma_e_);
+    OpenSnLogicalErrorIf(sigma_e_.empty(),
+                         "\"edep\" data block not found in " + file_name + ".");
+    // Charge deposition
+    H5ReadDataset1D<double>(file, path + "cdep", sigma_c_);
+    OpenSnLogicalErrorIf(sigma_c_.empty(),
+                         "\"cdep\" data block not found in " + file_name + ".");
+    // Stopping Power
+    H5ReadDataset1D<double>(file, path + "sp", stopping_power_);
+    OpenSnLogicalErrorIf(stopping_power_.empty(),
+                         "\"sp\" data block not found in " + file_name + ".");
+    // Momentum Transfer
+    H5ReadDataset1D<double>(file, path + "mt", momentum_transfer_);
+    OpenSnLogicalErrorIf(momentum_transfer_.empty(),
+                         "\"mt\" data block not found in " + file_name + ".");
+    // Density
+    H5ReadDataset1D<double>(file, path + "rho", density_);
+    OpenSnLogicalErrorIf(density_.empty(),
+                         "\"rho\" data block not found in " + file_name + ".");
+                     
+  } // Is charged particle?
+  else
+  {
+    // Clear electron data if not charged particle
+    sigma_e_.clear();
+    sigma_c_.clear();
+    stopping_power_.clear();
+    momentum_transfer_.clear();
+    density_.clear();
+  }  
   // Is fissionable?
   H5ReadGroupAttribute<bool>(file, dataset_name, "fissionable", is_fissionable_);
   if (is_fissionable_)

--- a/python/lib/xs.cc
+++ b/python/lib/xs.cc
@@ -98,13 +98,13 @@ WrapMultiGroupXS(py::module& xs)
     )"
   );
   multigroup_xs.def(
-    "LoadFromOpenMC",
+    "LoadFromHDF5",
     [](MultiGroupXS& self, const std::string& file_name, const std::string& dataset_name,
        double temperature)
     {
       self.Initialize(file_name, dataset_name, temperature);
     },
-    "Load multi-group cross sections from an OpenMC cross-section file.",
+    "Load multi-group cross sections from an HDF5 cross-section file.",
     py::arg("file_name"),
     py::arg("dataset_name"),
     py::arg("temperature")
@@ -139,6 +139,11 @@ WrapMultiGroupXS(py::module& xs)
     "scaling_factor",
     &MultiGroupXS::GetScalingFactor,
     "Get the arbitrary scaling factor."
+  );
+    multigroup_xs.def_property_readonly(
+    "is_bxslib",
+    &MultiGroupXS::IsBxslib,
+    "Check if contains electron data."
   );
   multigroup_xs.def_property_readonly(
     "sigma_t",
@@ -186,6 +191,36 @@ WrapMultiGroupXS(py::module& xs)
     "inv_velocity",
     XS_GETTER(GetInverseVelocity),
     "Get inverse velocity.",
+    py::keep_alive<0, 1>()
+  );
+  multigroup_xs.def_property_readonly(
+    "sigma_e",
+    XS_GETTER(GetSigmaEdep),
+    "Get energy deposition cross section.",
+    py::keep_alive<0, 1>()
+  );
+    multigroup_xs.def_property_readonly(
+    "sigma_c",
+    XS_GETTER(GetSigmaCdep),
+    "Get charge deposition cross section.",
+    py::keep_alive<0, 1>()
+  );
+    multigroup_xs.def_property_readonly(
+    "stopping_power",
+    XS_GETTER(GetStoppingPower),
+    "Get groupwise stopping powers.",
+    py::keep_alive<0, 1>()
+  );
+    multigroup_xs.def_property_readonly(
+    "momentum_transfer",
+    XS_GETTER(GetMomentumTransfer),
+    "Get groupwise momentum transfer data.",
+    py::keep_alive<0, 1>()
+  );
+    multigroup_xs.def_property_readonly(
+    "density",
+    XS_GETTER(GetDensity),
+    "Get material density data.",
     py::keep_alive<0, 1>()
   );
   // clang-format on


### PR DESCRIPTION
Existing HDF5 framework in OpenMC reader is able to read a properly-formatted electron data file as well. These slight updates make the method more generic (which might be contentious), as well as enable the reading and passing of electron relevant data for future use.